### PR TITLE
apng support etc

### DIFF
--- a/lib/defaults.rb
+++ b/lib/defaults.rb
@@ -10,8 +10,10 @@ module Ffmprb
   Process.duck_audio_volume_lo = 0.1
   Process.timeout = 30
 
+  Process.input_options = {noautorotate: true}
+
   Process.output_video_resolution = CGA
-  Process.output_video_fps = 30
+  Process.output_video_fps = 16
   Process.output_audio_encoder = 'libmp3lame'
 
   Util.ffmpeg_cmd = %w[ffmpeg -y]

--- a/lib/ffmprb/file.rb
+++ b/lib/ffmprb/file.rb
@@ -174,7 +174,7 @@ module Ffmprb
     end
 
     def image_extname?
-      extname =~ /^\.(jpe?g|png|y4m)$/i
+      extname =~ /^\.(jpe?g|a?png|y4m)$/i
     end
 
     def sound_extname?

--- a/lib/ffmprb/process.rb
+++ b/lib/ffmprb/process.rb
@@ -9,6 +9,8 @@ module Ffmprb
       attr_accessor :duck_audio_transition_length,
         :duck_audio_transition_in_start, :duck_audio_transition_out_start
 
+      attr_accessor :input_options
+
       attr_accessor :output_video_resolution
       attr_accessor :output_video_fps
       attr_accessor :output_audio_encoder
@@ -92,8 +94,8 @@ module Ffmprb
       fail Error, "Unknown options: #{opts}"  unless opts.empty?
     end
 
-    def input(io)
-      Input.new(io, self).tap do |inp|
+    def input(io, **opts)
+      Input.new(io, self, **self.class.input_options.merge(opts)).tap do |inp|
         @inputs << inp
       end
     end

--- a/lib/ffmprb/process/input.rb
+++ b/lib/ffmprb/process/input.rb
@@ -24,9 +24,10 @@ module Ffmprb
       attr_accessor :io
       attr_reader :process
 
-      def initialize(io, process)
+      def initialize(io, process, **opts)
         @io = self.class.resolve(io)
         @process = process
+        @opts = opts
       end
 
 
@@ -36,8 +37,13 @@ module Ffmprb
 
 
       def options
-        defaults = %w[-noautorotate -thread_queue_size 32 -i]  # TODO parameterise
-        defaults + [io.path]
+        opts = []
+        @opts.map do |name, value|
+          next  unless value
+          opts << "-#{name}"
+          opts << value  unless value == true
+        end
+        opts << '-i' << io.path
       end
 
       def filters_for(lbl, video:, audio:)


### PR DESCRIPTION
defaults change (fps=16); input options parameterisation (-noautorotate being the first); apng (moving image) format addition -- goes well with default_fps: (parameterised) input option
