### PR TITLE
read timeout class attribute correctly

### DIFF
--- a/lib/ffmprb/util/threaded_io_buffer.rb
+++ b/lib/ffmprb/util/threaded_io_buffer.rb
@@ -119,7 +119,7 @@ module Ffmprb
               rescue Timeout::Error  # NOTE the queue is probably overflown
                 @terminate = Error.new("The reader has failed with timeout while queuing")
                 # timeout!
-                fail Error, "Looks like we're stuck (#{timeout}s idle) with #{self.class.blocks_max}x#{self.class.block_size}B blocks (buffering #{reader_input!.path}->...)..."
+                fail Error, "Looks like we're stuck (#{self.class.timeout}s idle) with #{self.class.blocks_max}x#{self.class.block_size}B blocks (buffering #{reader_input!.path}->...)..."
               end
               @stat_blocks_max = blocks_count  if blocks_count > @stat_blocks_max
             end

--- a/spec/file_spec.rb
+++ b/spec/file_spec.rb
@@ -94,7 +94,7 @@ describe Ffmprb::File do
               end
             end
           end
-          expect{Ffmprb::Util::Thread.join_children!}.to raise_error StandardError
+          expect{Ffmprb::Util::Thread.join_children!}.to raise_error Ffmprb::Error
         ensure
           Ffmprb::Util::ThreadedIoBuffer.timeout = timeout
         end


### PR DESCRIPTION
and don't call `kernel#timeout`. Fixes issue #11
