### PR TITLE
Ducking transition should work for cases where silence have only start time

### DIFF
--- a/lib/ffmprb/process.rb
+++ b/lib/ffmprb/process.rb
@@ -61,17 +61,21 @@ module Ffmprb
             silence.each do |silent|
               next  if silent.end_at && silent.start_at && (silent.end_at - silent.start_at) < silent_min
 
-              transition_in_start = silent.start_at + Process.duck_audio_transition_in_start
-              ducked_overlay_volume.merge!(
-                [transition_in_start, 0.0].max => volume_lo,
-                (transition_in_start + Process.duck_audio_transition_length) => volume_hi
-              )  if silent.start_at
+              if silent.start_at
+                transition_in_start = silent.start_at + Process.duck_audio_transition_in_start
+                ducked_overlay_volume.merge!(
+                  [transition_in_start, 0.0].max => volume_lo,
+                  (transition_in_start + Process.duck_audio_transition_length) => volume_hi
+                )
+              end
 
-              transition_out_start = silent.end_at + Process.duck_audio_transition_out_start
-              ducked_overlay_volume.merge!(
-                [transition_out_start, 0.0].max => volume_hi,
-                (transition_out_start + Process.duck_audio_transition_length) => volume_lo
-              )  if silent.end_at
+              if silent.end_at
+                transition_out_start = silent.end_at + Process.duck_audio_transition_out_start
+                ducked_overlay_volume.merge!(
+                  [transition_out_start, 0.0].max => volume_hi,
+                  (transition_out_start + Process.duck_audio_transition_length) => volume_lo
+                )
+              end
             end
             overlay in_over.volume ducked_overlay_volume
 

--- a/spec/ffmprb_spec.rb
+++ b/spec/ffmprb_spec.rb
@@ -638,7 +638,7 @@ describe Ffmprb do
           expect(wave_data(sound).frequency).to be_within(10).of NOTES.G6
         end
 
-        expect(@av_out_stream.length).to be_approximately 10
+        expect(@av_out_stream.length).to be_approximately 16
       end
 
       it "should duck some overlay sound wrt some main sound" do

--- a/spec/ffmprb_spec.rb
+++ b/spec/ffmprb_spec.rb
@@ -622,8 +622,8 @@ describe Ffmprb do
           in1 = input(input1)
           in2 = input(input2)
           output(output1) do
-            lay in1.cut(to: 10), transition: {blend: 1}
-            overlay in2.cut(from: 4).loop, duck: :audio
+            lay in1, transition: {blend: 1}
+            overlay in2.loop, duck: :audio
           end
 
         end


### PR DESCRIPTION
Added check for `silent.start_at`/`silent.end_at` before it used in calculation of `transition_in_start`/`transition_out_start`

Should fix #13 
