### PR TITLE
Correction of detected silence start/end time

### DIFF
--- a/lib/ffmprb/find_silence.rb
+++ b/lib/ffmprb/find_silence.rb
@@ -29,7 +29,7 @@ module Ffmprb
 
     private
 
-    SILENCE_DETECT_REGEX = /\[silencedetect\s.*\]\s*silence_(\w+):\s*(\d+\.?d*)/
+    SILENCE_DETECT_REGEX = /\[silencedetect\s.*\]\s*silence_(\w+):\s*(\d+\.?\d*)/
 
     def find_silence_detect_options
       Filter.complex_options Filter.silencedetect


### PR DESCRIPTION
Currently start/end time of the detected silence is shifted towards start of the second due to incorrect regex (typo?)
