### PR TITLE
Audio ducking parameter for audible sound minimum length

### DIFF
--- a/lib/defaults.rb
+++ b/lib/defaults.rb
@@ -7,7 +7,7 @@ module Ffmprb
   Filter.silence_noise_max_db = -40
 
   Process.duck_audio_silent_min = 3
-  Process.duck_audio_audible_sound_min = 1
+  Process.duck_audio_audible_min = 1
   Process.duck_audio_transition_length = 1
   Process.duck_audio_transition_in_start = -0.4
   Process.duck_audio_transition_out_start = -0.6

--- a/lib/defaults.rb
+++ b/lib/defaults.rb
@@ -7,6 +7,7 @@ module Ffmprb
   Filter.silence_noise_max_db = -40
 
   Process.duck_audio_silent_min = 3
+  Process.duck_audio_audible_sound_min = 1
   Process.duck_audio_transition_length = 1
   Process.duck_audio_transition_in_start = -0.4
   Process.duck_audio_transition_out_start = -0.6

--- a/lib/ffmprb/process.rb
+++ b/lib/ffmprb/process.rb
@@ -68,7 +68,7 @@ module Ffmprb
                 next_silent.overlaps = silent_part
               end
             end
-            silence.delete_if {|silent| silent.overlaps}
+            silence.delete_if &:overlaps
 
             silence.each do |silent|
               next  if silent.end_at && silent.start_at && (silent.end_at - silent.start_at) < silent_min

--- a/lib/ffmprb/process.rb
+++ b/lib/ffmprb/process.rb
@@ -60,7 +60,8 @@ module Ffmprb
 
             ducked_overlay_volume = {0.0 => volume_lo}
 
-            silence.each_cons(2) do |(silent, next_silent)|
+            silent_fragments = silence.map &:clone
+            silent_fragments.each_cons(2) do |(silent, next_silent)|
               silent_part = silent.overlaps || silent
 
               if silent_part.end_at.nil? or (next_silent.start_at - silent_part.end_at) < audible_min
@@ -68,9 +69,9 @@ module Ffmprb
                 next_silent.overlaps = silent_part
               end
             end
-            silence.delete_if &:overlaps
+            silent_fragments.delete_if &:overlaps
 
-            silence.each do |silent|
+            silent_fragments.each do |silent|
               next  if silent.end_at && silent.start_at && (silent.end_at - silent.start_at) < silent_min
 
               if silent.start_at

--- a/lib/ffmprb/process.rb
+++ b/lib/ffmprb/process.rb
@@ -5,7 +5,7 @@ module Ffmprb
     class << self
 
       attr_accessor :duck_audio_volume_hi, :duck_audio_volume_lo,
-        :duck_audio_silent_min, :duck_audio_audible_sound_min
+        :duck_audio_silent_min, :duck_audio_audible_min
       attr_accessor :duck_audio_transition_length,
         :duck_audio_transition_in_start, :duck_audio_transition_out_start
 
@@ -43,13 +43,13 @@ module Ffmprb
 
       # NOTE Temporarily, av_main_i/o and not a_main_i/o
       def duck_audio(av_main_i, a_overlay_i, silence, av_main_o,
-        volume_lo: duck_audio_volume_lo,
-        volume_hi: duck_audio_volume_hi,
-        silent_min: duck_audio_silent_min,
-        audible_sound_min: duck_audio_audible_sound_min,
-        process_options: {},
-        video:,  # NOTE Temporarily, video should not be here
-        audio:
+                     volume_lo: duck_audio_volume_lo,
+                     volume_hi: duck_audio_volume_hi,
+                     silent_min: duck_audio_silent_min,
+                     audible_min: duck_audio_audible_min,
+                     process_options: {},
+                     video:, # NOTE Temporarily, video should not be here
+                     audio:
         )
         Ffmprb.process **process_options do
 
@@ -63,7 +63,7 @@ module Ffmprb
             silence.each_cons(2) do |(silent, next_silent)|
               silent_part = silent.overlaps || silent
 
-              if silent_part.end_at.nil? or (next_silent.start_at - silent_part.end_at) < audible_sound_min
+              if silent_part.end_at.nil? or (next_silent.start_at - silent_part.end_at) < audible_min
                 silent_part.end_at = next_silent.end_at
                 next_silent.overlaps = silent_part
               end

--- a/spec/ffmprb_spec.rb
+++ b/spec/ffmprb_spec.rb
@@ -615,7 +615,7 @@ describe Ffmprb do
         ).to be_approximately NOTES.B6
       end
 
-      it "should not duck on short sound peeks" do
+      it "should not duck on short sound peaks" do
 
         if Ffmprb::Process.duck_audio_audible_min == 0
           skip
@@ -630,6 +630,8 @@ describe Ffmprb do
 
             a_file_a6_10 = Ffmprb::File.temp('.wav')
             Ffmprb::Util.ffmpeg *Ffmprb::Filter.complex_options("sine=#{NOTES.A6}:d=10, volume=10dB"), a_file_a6_10.path
+
+            # Generating video with silence (longer than `duck_audio_silent_min`) and single peak (shorter than `duck_audio_audible_min`) so the
             av_file_a6_wtb = Ffmprb::File.temp('.mp4')
             Ffmprb::Util.ffmpeg *Ffmprb::Filter.complex_options("sine=#{NOTES.A6}:d=#{note_length}, volume=volume=6dB [note]", "aevalsrc=0:d=#{silence_length}, asplit [silence1][silence2]", '[silence1] [note] [silence2]concat=3:v=0:a=1, asplit [aux][aux2]', '[aux]avectorscope,format=yuv420p[vid]'),*['-map','[vid]','-map','[aux2]'], av_file_a6_wtb.path
 
@@ -647,6 +649,8 @@ describe Ffmprb do
 
             aout = wave_data @av_out_stream.sample at: silence_length+0.01, video: false
 
+            # We use two incoherent sound sources using same note but different level (http://www.sengpielaudio.com/calculator-leveladding.htm)
+            # Ensure background music is louder than video and mixed result audio level is louder than background
             expect(bg.volume).to be > fg.volume
             expect(aout.volume).to be > bg.volume
             expect(aout.frequency).to be_within(10).of NOTES.A6

--- a/spec/ffmprb_spec.rb
+++ b/spec/ffmprb_spec.rb
@@ -615,6 +615,28 @@ describe Ffmprb do
         ).to be_approximately NOTES.B6
       end
 
+      it "should not duck on short sound peeks" do
+
+        Ffmprb.process(@av_file_a6_wtb, @a_file_a6_10, @av_out_stream) do |input1, input2, output1|
+          in1 = input(input1)
+          in2 = input(input2)
+          output(output1) do
+            lay in1
+            overlay in2.loop, duck: :audio
+          end
+        end
+
+        fg = wave_data @av_file_a6_wtb.sample at:5, video: false
+        bg = wave_data @a_file_a6_10.sample at:5, video: false
+        aout = wave_data @av_out_stream.sample at: 5, video: false
+
+        expect(bg.volume).to be > fg.volume
+        expect(aout.volume).to be > bg.volume
+        expect(aout.frequency).to be_within(10).of NOTES.A6
+
+        expect(@av_out_stream.length).to be_approximately @av_file_a6_wtb.length
+      end
+
       it "should duck the overlay sound wrt the main sound" do
         # NOTE non-streaming output file requires additional development see #181845
         Ffmprb.process(@av_file_btn_wtb_16, @a_file_g_16, @av_out_stream) do |input1, input2, output1|

--- a/spec/ffmprb_spec.rb
+++ b/spec/ffmprb_spec.rb
@@ -617,11 +617,11 @@ describe Ffmprb do
 
       it "should not duck on short sound peeks" do
 
-        if Ffmprb::Process.duck_audio_audible_sound_min == 0
+        if Ffmprb::Process.duck_audio_audible_min == 0
           skip
         end
 
-        note_length = Ffmprb::Process.duck_audio_audible_sound_min/2.00
+        note_length = Ffmprb::Process.duck_audio_audible_min/2.00
         silence_length = (1 + Ffmprb::Process.duck_audio_silent_min * 1.5).round
 
         Ffmprb::Process.output_audio_encoder.tap do |aencoder|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,10 @@ RSpec.configure do |config|
     Ffmprb::Util.ffmpeg *Ffmprb::Filter.complex_options('color=red:r=30:d=6:s=320x240, setpts=PTS-STARTPTS [red]', 'color=green:r=30:d=6:s=280x200 [green]', '[red] [green] overlay=20:20'), '-pix_fmt', 'yuv420p', @v_file_6.path
     @a_file_g_16 = Ffmprb::File.temp('.mp3')
     Ffmprb::Util.ffmpeg *Ffmprb::Filter.complex_options("sine=#{NOTES.G6}:d=16"), @a_file_g_16.path
+    @a_file_a6_10 = Ffmprb::File.temp('.mp3')
+    Ffmprb::Util.ffmpeg *Ffmprb::Filter.complex_options("sine=#{NOTES.A6}:d=10, volume=10dB"), @a_file_a6_10.path
+    @av_file_a6_wtb = Ffmprb::File.temp('.mp4')
+    Ffmprb::Util.ffmpeg *Ffmprb::Filter.complex_options('color=white:d=0.6, split [wh1a] [wh1b]', 'color=black:d=4.2, split [bl1a] [bl1b]', "sine=#{NOTES.A6}:d=0.6, volume=volume=6dB, asplit [na5a] [na5b]", 'aevalsrc=0:d=4.2, asplit [si1a] [si1b]', '[wh1a] [na5a] [bl1a] [si1a] [wh1b] [na5b] [bl1b] [si1b] concat=4:v=1:a=1'), @av_file_a6_wtb.path
   end
 
   config.after :all do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,10 +25,6 @@ RSpec.configure do |config|
     Ffmprb::Util.ffmpeg *Ffmprb::Filter.complex_options('color=red:r=30:d=6:s=320x240, setpts=PTS-STARTPTS [red]', 'color=green:r=30:d=6:s=280x200 [green]', '[red] [green] overlay=20:20'), '-pix_fmt', 'yuv420p', @v_file_6.path
     @a_file_g_16 = Ffmprb::File.temp('.mp3')
     Ffmprb::Util.ffmpeg *Ffmprb::Filter.complex_options("sine=#{NOTES.G6}:d=16"), @a_file_g_16.path
-    @a_file_a6_10 = Ffmprb::File.temp('.mp3')
-    Ffmprb::Util.ffmpeg *Ffmprb::Filter.complex_options("sine=#{NOTES.A6}:d=10, volume=10dB"), @a_file_a6_10.path
-    @av_file_a6_wtb = Ffmprb::File.temp('.mp4')
-    Ffmprb::Util.ffmpeg *Ffmprb::Filter.complex_options('color=white:d=0.6, split [wh1a] [wh1b]', 'color=black:d=4.2, split [bl1a] [bl1b]', "sine=#{NOTES.A6}:d=0.6, volume=volume=6dB, asplit [na5a] [na5b]", 'aevalsrc=0:d=4.2, asplit [si1a] [si1b]', '[wh1a] [na5a] [bl1a] [si1a] [wh1b] [na5b] [bl1b] [si1b] concat=4:v=1:a=1'), @av_file_a6_wtb.path
   end
 
   config.after :all do
@@ -38,8 +34,6 @@ RSpec.configure do |config|
     # @av_file_ro7_14.remove
     @v_file_6.remove
     @a_file_g_16.remove
-    @a_file_a6_10.remove
-    @av_file_a6_wtb.remove
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,8 @@ RSpec.configure do |config|
     # @av_file_ro7_14.remove
     @v_file_6.remove
     @a_file_g_16.remove
+    @a_file_a6_10.remove
+    @av_file_a6_wtb.remove
   end
 
 end


### PR DESCRIPTION
There are cases when silence broken for a short time by some SFX and it's desirable for the purpose of ducking to expand silence period covering SFX (by joining two silence blocks around sound that lasts less than `duck_audio_audible_sound_min` seconds).
